### PR TITLE
Change to links in haxelib/readme 

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -2,7 +2,7 @@
 , "description" : "Newgrounds API for haxe"
 , "version"     : "2.0.2"
 , "releasenote" : "fix warnings on haxe 4.3.1"
-, "url"         : "https://newgrounds.io/"
+, "url"         : "https://github.com/Geokureli/Newgrounds"
 , "classPath"   : "lib/Source"
 , "license"     : "MIT"
 , "tags"        : ["newgrounds", "ng.io", "web", "strawberryclock"]


### PR DESCRIPTION
Small little things that changes links around... 

1.  On almost all of the haxelibs on lib.haxe.org, the URL points to the source code repo. PERSONALLY I use that link a lot to easily poke at the source code! However this haxelib.json points to newgrounds.io. I've updated it to point towards this github repo
2. Added easy and quick link in the readme that is a simple and clear pointer to Newgrounds.io, in case we REALLY WANT a direct and clear link to the site. Feel free to change how you please or remove! 